### PR TITLE
add image annotation in chart metadata

### DIFF
--- a/charts/helm/Chart.yaml
+++ b/charts/helm/Chart.yaml
@@ -1,5 +1,9 @@
 # Copyright Omnistrate, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
+annotations:
+  omnistrate.com/images: |
+    - name: licensing-example-java
+      image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
 
 apiVersion: v2
 name: licensing-example-java


### PR DESCRIPTION
This pull request adds an annotation to the `charts/helm/Chart.yaml` file to document the container image used for the `licensing-example-java` chart. This helps clarify which image is deployed and makes it easier for users and automated tooling to identify the image reference.

* Chart metadata improvement:
  * Added an `omnistrate.com/images` annotation specifying the container image and tag for the `licensing-example-java` chart in `Chart.yaml`.